### PR TITLE
Add libidn package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM neilpang/acme.sh
 ENV AWS_ROLE_ARN $AWS_ROLE_ARN
 ENV AWS_ROLE_NAME $AWS_ROLE_NAME
 
-RUN apk --no-cache add -f jq python py-pip && rm -rf /var/cache/apk/*
+RUN apk --no-cache add -f jq python py-pip libidn && rm -rf /var/cache/apk/*
 RUN pip install awscli
 
 COPY ./entrypoint.sh /usr/local/bin/entrypoint.sh


### PR DESCRIPTION
For the record, this should not be here, but I am piggybacking on this project to include libidn so it resolves this error:

```
It seems that _acme-challenge.mydomain.com is an IDN( Internationalized Domain Names), please install 'idn' command first
```
